### PR TITLE
fix: Flatten optimism hoisted tx fields

### DIFF
--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -29,9 +29,8 @@ pub struct BlockEnv {
     pub basefee: U256,
     pub gas_limit: U256,
 }
-
-#[derive(Clone, Debug, Default)]
 #[cfg(feature = "optimism")]
+#[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OptimismFields {
     pub source_hash: Option<B256>,

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -30,6 +30,16 @@ pub struct BlockEnv {
     pub gas_limit: U256,
 }
 
+#[derive(Clone, Debug, Default)]
+#[cfg(feature = "optimism")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct OptimismFields {
+    pub source_hash: Option<B256>,
+    pub mint: Option<u128>,
+    pub is_system_transaction: Option<bool>,
+    pub l1_cost: Option<U256>,
+}
+
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TxEnv {
@@ -45,14 +55,9 @@ pub struct TxEnv {
     pub chain_id: Option<u64>,
     pub nonce: Option<u64>,
     pub access_list: Vec<(B160, Vec<U256>)>,
+    #[cfg_attr(feature = "serde", serde(flatten))]
     #[cfg(feature = "optimism")]
-    pub source_hash: Option<B256>,
-    #[cfg(feature = "optimism")]
-    pub mint: Option<u128>,
-    #[cfg(feature = "optimism")]
-    pub is_system_transaction: Option<bool>,
-    #[cfg(feature = "optimism")]
-    pub l1_cost: Option<U256>,
+    pub optimism: OptimismFields,
 }
 
 #[derive(Clone, Debug)]
@@ -261,13 +266,7 @@ impl Default for TxEnv {
             nonce: None,
             access_list: Vec::new(),
             #[cfg(feature = "optimism")]
-            source_hash: None,
-            #[cfg(feature = "optimism")]
-            mint: None,
-            #[cfg(feature = "optimism")]
-            is_system_transaction: None,
-            #[cfg(feature = "optimism")]
-            l1_cost: None,
+            optimism: OptimismFields::default(),
         }
     }
 }
@@ -304,12 +303,14 @@ impl Env {
         #[cfg(feature = "optimism")]
         if self.cfg.optimism {
             // Do not allow for a system transaction to be processed if Regolith is enabled.
-            if self.tx.is_system_transaction.unwrap_or(false) && SPEC::enabled(SpecId::REGOLITH) {
+            if self.tx.optimism.is_system_transaction.unwrap_or(false)
+                && SPEC::enabled(SpecId::REGOLITH)
+            {
                 return Err(InvalidTransaction::DepositSystemTxPostRegolith);
             }
 
             // Do not perform any extra validation for deposit transactions, they are pre-verified on L1.
-            if self.tx.source_hash.is_some() {
+            if self.tx.optimism.source_hash.is_some() {
                 return Ok(());
             }
         }
@@ -379,7 +380,7 @@ impl Env {
         // On Optimism, deposit transactions do not have verification on the nonce
         // nor the balance of the account.
         #[cfg(feature = "optimism")]
-        if self.cfg.optimism && self.tx.source_hash.is_some() {
+        if self.cfg.optimism && self.tx.optimism.source_hash.is_some() {
             return Ok(());
         }
 

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -134,10 +134,10 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
         let effective_gas_price = env.effective_gas_price();
         #[cfg(feature = "optimism")]
         let (tx_mint, tx_system, tx_l1_cost, is_deposit) = (
-            env.tx.mint,
-            env.tx.is_system_transaction,
-            env.tx.l1_cost,
-            env.tx.source_hash.is_some(),
+            env.tx.optimism.mint,
+            env.tx.optimism.is_system_transaction,
+            env.tx.optimism.l1_cost,
+            env.tx.optimism.source_hash.is_some(),
         );
 
         let initial_gas_spend =
@@ -379,7 +379,8 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
             let is_gas_refund_disabled = self.data.env.cfg.is_gas_refund_disabled();
 
             #[cfg(feature = "optimism")]
-            let is_deposit = self.data.env.cfg.optimism && self.data.env.tx.source_hash.is_some();
+            let is_deposit =
+                self.data.env.cfg.optimism && self.data.env.tx.optimism.source_hash.is_some();
 
             // Prior to Regolith, deposit transactions did not receive gas refunds.
             #[cfg(feature = "optimism")]
@@ -447,11 +448,11 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
                 };
 
                 // Send the L1 cost of the transaction to the L1 Fee Vault.
-                if let Some(l1_cost) = self.data.env.tx.l1_cost {
+                if let Some(l1_cost) = self.data.env.tx.optimism.l1_cost {
                     let Ok((l1_fee_vault_account, _)) = self
                         .data
                         .journaled_state
-                        .load_account(optimism::L1_FEE_RECIPIENT.into(), self.data.db)
+                        .load_account(optimism::L1_FEE_RECIPIENT, self.data.db)
                     else {
                         panic!("[OPTIMISM] Failed to load L1 Fee Vault account");
                     };
@@ -463,7 +464,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
                 let Ok((base_fee_vault_account, _)) = self
                     .data
                     .journaled_state
-                    .load_account(optimism::BASE_FEE_RECIPIENT.into(), self.data.db)
+                    .load_account(optimism::BASE_FEE_RECIPIENT, self.data.db)
                 else {
                     panic!("[OPTIMISM] Failed to load Base Fee Vault account");
                 };

--- a/crates/revm/src/optimism.rs
+++ b/crates/revm/src/optimism.rs
@@ -45,9 +45,9 @@ pub struct L1BlockInfo {
 impl L1BlockInfo {
     /// Fetches the L1 block info from the `L1Block` contract in the database.
     pub fn try_fetch<DB: Database>(db: &mut DB) -> Result<L1BlockInfo, DB::Error> {
-        let l1_base_fee = db.storage(L1_BLOCK_CONTRACT.into(), L1_BASE_FEE_SLOT)?;
-        let l1_fee_overhead = db.storage(L1_BLOCK_CONTRACT.into(), L1_OVERHEAD_SLOT)?;
-        let l1_fee_scalar = db.storage(L1_BLOCK_CONTRACT.into(), L1_SCALAR_SLOT)?;
+        let l1_base_fee = db.storage(L1_BLOCK_CONTRACT, L1_BASE_FEE_SLOT)?;
+        let l1_fee_overhead = db.storage(L1_BLOCK_CONTRACT, L1_OVERHEAD_SLOT)?;
+        let l1_fee_scalar = db.storage(L1_BLOCK_CONTRACT, L1_SCALAR_SLOT)?;
 
         Ok(L1BlockInfo {
             l1_base_fee,


### PR DESCRIPTION
**Description**

Hoists optimism tx fields into a flattened struct.

See [comment](https://github.com/bluealloy/revm/pull/682/files#r1315733519) left on the upstream pr.