### PR TITLE
rfc: Stub optimism feature binary error

### DIFF
--- a/bins/revme/Cargo.toml
+++ b/bins/revme/Cargo.toml
@@ -32,3 +32,6 @@ thiserror = "1.0"
 triehash = "0.8"
 walkdir = "2.3"
 hex-literal = "0.4"
+
+[features]
+optimism = [ "revm/optimism" ]

--- a/bins/revme/src/cmd.rs
+++ b/bins/revme/src/cmd.rs
@@ -21,6 +21,10 @@ pub enum Error {
 
 impl MainCmd {
     pub fn run(&self) -> Result<(), Error> {
+        if cfg!(feature = "optimism") {
+            eprintln!("optimism not supported");
+            return Err(Error::SystemError);
+        }
         match self {
             Self::Statetest(cmd) => cmd.run().map_err(Error::Statetest),
             _ => Ok(()),


### PR DESCRIPTION
**Description**

Adds a stubbed error to the ethereum/tests binary to prevent user footguns if the optimism feature flag is enabled when running ethereum tests.