### PR TITLE
fix: SpecId Enabled

### DIFF
--- a/crates/primitives/src/specification.rs
+++ b/crates/primitives/src/specification.rs
@@ -77,14 +77,19 @@ pub trait Spec: Sized {
 
     #[inline(always)]
     fn enabled(spec_id: SpecId) -> bool {
+        // If the Spec is Bedrock or Regolith, and the input is not Bedrock or Regolith,
+        // then no hardforks should be enabled after the merge.
+        let is_self_optimism =
+            Self::SPEC_ID == SpecId::BEDROCK || Self::SPEC_ID == SpecId::REGOLITH;
+        let input_not_optimism = spec_id != SpecId::BEDROCK && spec_id != SpecId::REGOLITH;
+        let after_merge = spec_id > SpecId::MERGE;
+
         // Optimism's Bedrock and Regolith hardforks implement changes on top of the Merge
         // hardfork. This function is modified to preserve the original behavior of the
         // spec IDs without having to put hardforks past Merge under
         // `#[cfg(not(feature = "optimism"))]`.
         #[cfg(feature = "optimism")]
-        if (Self::SPEC_ID == SpecId::BEDROCK || Self::SPEC_ID == SpecId::REGOLITH)
-            && spec_id > SpecId::MERGE
-        {
+        if is_self_optimism && input_not_optimism && after_merge {
             return false;
         }
 
@@ -128,3 +133,30 @@ spec!(LATEST, LatestSpec);
 spec!(BEDROCK, BedrockSpec);
 #[cfg(feature = "optimism")]
 spec!(REGOLITH, RegolithSpec);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "optimism")]
+    #[test]
+    fn test_bedrock_post_merge_hardforks() {
+        assert!(BedrockSpec::enabled(SpecId::MERGE));
+        assert!(!BedrockSpec::enabled(SpecId::SHANGHAI));
+        assert!(!BedrockSpec::enabled(SpecId::CANCUN));
+        assert!(!BedrockSpec::enabled(SpecId::LATEST));
+        assert!(BedrockSpec::enabled(SpecId::BEDROCK));
+        assert!(!BedrockSpec::enabled(SpecId::REGOLITH));
+    }
+
+    #[cfg(feature = "optimism")]
+    #[test]
+    fn test_regolith_post_merge_hardforks() {
+        assert!(RegolithSpec::enabled(SpecId::MERGE));
+        assert!(!RegolithSpec::enabled(SpecId::SHANGHAI));
+        assert!(!RegolithSpec::enabled(SpecId::CANCUN));
+        assert!(!RegolithSpec::enabled(SpecId::LATEST));
+        assert!(RegolithSpec::enabled(SpecId::BEDROCK));
+        assert!(RegolithSpec::enabled(SpecId::REGOLITH));
+    }
+}

--- a/crates/revm/src/optimism.rs
+++ b/crates/revm/src/optimism.rs
@@ -94,3 +94,32 @@ impl L1BlockInfo {
             .unwrap_or_default()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::specification::*;
+
+    #[test]
+    fn test_data_gas() {
+        let l1_block_info = L1BlockInfo {
+            l1_base_fee: U256::from(1_000_000),
+            l1_fee_overhead: U256::from(1_000_000),
+            l1_fee_scalar: U256::from(1_000_000),
+        };
+
+        // 0xFACADE = 6 nibbles = 3 bytes
+        // 1111 1010 | 1100 1010 | 1101 1110
+        // 111110101100101011011110
+        //
+        // gas cost = 3 non-zero bytes * NON_ZERO_BYTE_COST
+        // gas cost += NON_ZERO_BYTE_COST * 68
+
+        let input = Bytes::from(hex!("FACADE").to_vec());
+        let bedrock_data_gas = l1_block_info.data_gas::<BedrockSpec>(&input);
+        assert_eq!(bedrock_data_gas, U256::from(1136));
+
+        let regolith_data_gas = l1_block_info.data_gas::<RegolithSpec>(&input);
+        assert_eq!(regolith_data_gas, U256::from(48));
+    }
+}

--- a/crates/revm/src/optimism.rs
+++ b/crates/revm/src/optimism.rs
@@ -163,5 +163,10 @@ mod tests {
 
         let gas_cost = l1_block_info.calculate_tx_l1_cost::<RegolithSpec>(&input, false);
         assert_eq!(gas_cost, U256::from(1048));
+
+        // Zero rollup data gas cost should result in zero for non-deposits
+        let input = Bytes::from(hex!("").to_vec());
+        let gas_cost = l1_block_info.calculate_tx_l1_cost::<RegolithSpec>(&input, false);
+        assert_eq!(gas_cost, U256::ZERO);
     }
 }

--- a/crates/revm/src/optimism.rs
+++ b/crates/revm/src/optimism.rs
@@ -147,4 +147,21 @@ mod tests {
         let regolith_data_gas = l1_block_info.data_gas::<RegolithSpec>(&input);
         assert_eq!(regolith_data_gas, U256::from(56));
     }
+
+    #[test]
+    fn test_calculate_tx_l1_cost() {
+        let l1_block_info = L1BlockInfo {
+            l1_base_fee: U256::from(1_000),
+            l1_fee_overhead: U256::from(1_000),
+            l1_fee_scalar: U256::from(1_000),
+        };
+
+        // The gas cost here should be zero since the tx is a deposit
+        let input = Bytes::from(hex!("FACADE").to_vec());
+        let gas_cost = l1_block_info.calculate_tx_l1_cost::<BedrockSpec>(&input, true);
+        assert_eq!(gas_cost, U256::ZERO);
+
+        let gas_cost = l1_block_info.calculate_tx_l1_cost::<RegolithSpec>(&input, false);
+        assert_eq!(gas_cost, U256::from(1048));
+    }
 }


### PR DESCRIPTION
**Description**

Fix the `enabled` method for optimism hardfork enabling.

Adds unit tests.