### PR TITLE
feat: EVM Impl Tests

### DIFF
--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -1122,3 +1122,59 @@ impl<'a, GSPEC: Spec, DB: Database + 'a, const INSPECT: bool> Host
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::db::InMemoryDB;
+    use crate::primitives::specification::BedrockSpec;
+    use crate::primitives::state::AccountInfo;
+
+    #[cfg(feature = "optimism")]
+    #[test]
+    fn test_commit_mint_value() {
+        let caller = B160::zero();
+        let mint_value = Some(1u128);
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            caller,
+            AccountInfo {
+                nonce: 0,
+                balance: U256::from(100),
+                code_hash: B256::zero(),
+                code: None,
+            },
+        );
+        let mut journal = JournaledState::new(0);
+        journal
+            .initial_account_load(caller, &[U256::from(100)], &mut db)
+            .unwrap();
+        assert!(
+            EVMImpl::<BedrockSpec, InMemoryDB, false>::commit_mint_value(
+                caller,
+                mint_value,
+                &mut db,
+                &mut journal
+            )
+            .is_ok(),
+        );
+
+        // Check the account balance is updated.
+        let (account, _) = journal.load_account(caller, &mut db).unwrap();
+        assert_eq!(account.info.balance, U256::from(101));
+
+        // No mint value should be a no-op.
+        assert!(
+            EVMImpl::<BedrockSpec, InMemoryDB, false>::commit_mint_value(
+                caller,
+                None,
+                &mut db,
+                &mut journal
+            )
+            .is_ok(),
+        );
+        let (account, _) = journal.load_account(caller, &mut db).unwrap();
+        assert_eq!(account.info.balance, U256::from(101));
+    }
+}


### PR DESCRIPTION
**Description**

Adds tests on the `EVMImpl` optimism-specific associated functions.

Gas usage methods are not tested here since they'll be hoisted onto the `Gas` struct in #6.