### PR TITLE
fix: Swap the l1_cost to use enveloped tx bytes

### DIFF
--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -37,7 +37,7 @@ pub struct OptimismFields {
     pub mint: Option<u128>,
     pub is_system_transaction: Option<bool>,
     /// An enveloped EIP-2718 typed transaction. This is used
-    /// to compute the l1 tx cost using the l1 block info, as
+    /// to compute the L1 tx cost using the L1 block info, as
     /// opposed to requiring downstream apps to compute the cost
     /// externally.
     pub enveloped_tx: Bytes,

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -36,7 +36,11 @@ pub struct OptimismFields {
     pub source_hash: Option<B256>,
     pub mint: Option<u128>,
     pub is_system_transaction: Option<bool>,
-    pub l1_cost: Option<U256>,
+    /// An enveloped EIP-2718 typed transaction. This is used
+    /// to compute the l1 tx cost using the l1 block info, as
+    /// opposed to requiring downstream apps to compute the cost
+    /// externally.
+    pub enveloped_tx: Bytes,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -111,10 +111,10 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
             .0;
         if l1_cost.gt(&acc.info.balance) {
             let x = l1_cost.as_limbs();
-            let u64_cost = if x[1] == 0 && x[2] == 0 && x[3] == 0 {
-                x[0]
-            } else {
+            let u64_cost = if U256::from(u64::MAX).lt(&l1_cost) {
                 u64::MAX
+            } else {
+                l1_cost.as_limbs()[0]
             };
             return Err(EVMError::Transaction(
                 InvalidTransaction::LackOfFundForMaxFee {

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -491,7 +491,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
                     is_deposit,
                 );
 
-                // Send the L1 cost of the transaction to the L1 Fee Vault.               if let Some(l1_cost) = self.data.env.tx.optimism.l1_cost {
+                // Send the L1 cost of the transaction to the L1 Fee Vault.
                 let Ok((l1_fee_vault_account, _)) = self
                     .data
                     .journaled_state


### PR DESCRIPTION
**Description**

Instead of pushing the l1 cost computation onto downstream op-revm users, change the tx environment to accept the enveloped 2718 tx bytes which can be used to compute the l1 tx cost using the l1 block info inside op-revm.

This makes for a cleaner interface and avoids exposing a leaky l1 cost computation.