### PR TITLE
perf: Reduce DB reads

### DIFF
--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -197,7 +197,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
                 optimism::L1BlockInfo::try_fetch(self.data.db, self.data.env.cfg.optimism)?;
 
             // Perform this calculation optimistically to avoid cloning the enveloped tx.
-            let tx_l1_cost = l1_block_info.clone().map(|l1_block_info| {
+            let tx_l1_cost = l1_block_info.as_ref().map(|l1_block_info| {
                 l1_block_info
                     .calculate_tx_l1_cost::<GSPEC>(&env.tx.optimism.enveloped_tx, is_deposit)
             });

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -194,7 +194,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
             let is_deposit = env.tx.optimism.source_hash.is_some();
 
             let l1_block_info =
-                optimism::L1BlockInfo::try_fetch_mut(self.data.db, self.data.env.cfg.optimism)?;
+                optimism::L1BlockInfo::try_fetch(self.data.db, self.data.env.cfg.optimism)?;
 
             // Perform this calculation optimistically to avoid cloning the enveloped tx.
             let tx_l1_cost = l1_block_info.clone().map(|l1_block_info| {

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -190,18 +190,25 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
         let effective_gas_price = env.effective_gas_price();
 
         #[cfg(feature = "optimism")]
-        let (tx_mint, tx_system, is_deposit) = (
-            env.tx.optimism.mint,
-            env.tx.optimism.is_system_transaction,
-            env.tx.optimism.source_hash.is_some(),
-        );
+        let (tx_mint, tx_system, tx_l1_cost, is_deposit, l1_block_info) = {
+            let is_deposit = env.tx.optimism.source_hash.is_some();
 
-        // Perform this calculation optimistically to avoid cloning the enveloped tx.
-        #[cfg(feature = "optimism")]
-        let tx_l1_cost = {
             let l1_block_info =
-                optimism::L1BlockInfo::try_fetch(&mut self.data.db).map_err(EVMError::Database)?;
-            l1_block_info.calculate_tx_l1_cost::<GSPEC>(&env.tx.optimism.enveloped_tx, is_deposit)
+                optimism::L1BlockInfo::try_fetch_mut(self.data.db, self.data.env.cfg.optimism)?;
+
+            // Perform this calculation optimistically to avoid cloning the enveloped tx.
+            let tx_l1_cost = l1_block_info.clone().map(|l1_block_info| {
+                l1_block_info
+                    .calculate_tx_l1_cost::<GSPEC>(&env.tx.optimism.enveloped_tx, is_deposit)
+            });
+
+            (
+                env.tx.optimism.mint,
+                env.tx.optimism.is_system_transaction,
+                tx_l1_cost,
+                is_deposit,
+                l1_block_info,
+            )
         };
 
         let initial_gas_spend =
@@ -229,6 +236,9 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
                 journal,
             )?;
 
+            let Some(tx_l1_cost) = tx_l1_cost else {
+                panic!("[OPTIMISM] L1 Block Info could not be loaded from the DB.")
+            };
             EVMImpl::<GSPEC, DB, INSPECT>::remove_l1_cost(
                 is_deposit,
                 tx_caller,
@@ -328,7 +338,11 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
             }
         }
 
-        let (state, logs, gas_used, gas_refunded) = self.finalize::<GSPEC>(&gas);
+        let (state, logs, gas_used, gas_refunded) = self.finalize::<GSPEC>(
+            &gas,
+            #[cfg(feature = "optimism")]
+            l1_block_info.as_ref(),
+        );
 
         let result = match exit_reason.into() {
             SuccessOrHalt::Success(reason) => ExecutionResult::Success {
@@ -407,7 +421,11 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
         }
     }
 
-    fn finalize<SPEC: Spec>(&mut self, gas: &Gas) -> (HashMap<B160, Account>, Vec<Log>, u64, u64) {
+    fn finalize<SPEC: Spec>(
+        &mut self,
+        gas: &Gas,
+        #[cfg(feature = "optimism")] l1_block_info: Option<&optimism::L1BlockInfo>,
+    ) -> (HashMap<B160, Account>, Vec<Log>, u64, u64) {
         let caller = self.data.env.tx.caller;
         let coinbase = self.data.env.block.coinbase;
         let (gas_used, gas_refunded) = if crate::USE_GAS {
@@ -480,8 +498,7 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> EVMImpl<'a, GSPEC, DB, 
             if self.data.env.cfg.optimism && !is_deposit {
                 // If the transaction is not a deposit transaction, fees are paid out
                 // to both the Base Fee Vault as well as the L1 Fee Vault.
-
-                let Ok(l1_block_info) = optimism::L1BlockInfo::try_fetch(&mut self.data.db) else {
+                let Some(l1_block_info) = l1_block_info else {
                     panic!("[OPTIMISM] Failed to load L1 block information.");
                 };
 

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -194,7 +194,8 @@ impl<'a, GSPEC: Spec, DB: Database, const INSPECT: bool> Transact<DB::Error>
             let is_deposit = env.tx.optimism.source_hash.is_some();
 
             let l1_block_info =
-                optimism::L1BlockInfo::try_fetch(self.data.db, self.data.env.cfg.optimism)?;
+                optimism::L1BlockInfo::try_fetch(self.data.db, self.data.env.cfg.optimism)
+                    .map_err(EVMError::Database)?;
 
             // Perform this calculation optimistically to avoid cloning the enveloped tx.
             let tx_l1_cost = l1_block_info.as_ref().map(|l1_block_info| {

--- a/crates/revm/src/optimism.rs
+++ b/crates/revm/src/optimism.rs
@@ -2,7 +2,7 @@
 
 use core::ops::Mul;
 use revm_interpreter::primitives::{
-    db::Database, hex_literal::hex, Bytes, EVMError, Spec, SpecId, B160, U256,
+    db::Database, hex_literal::hex, Bytes, Spec, SpecId, B160, U256,
 };
 
 const ZERO_BYTE_COST: u64 = 4;
@@ -46,18 +46,12 @@ impl L1BlockInfo {
     pub fn try_fetch<DB: Database>(
         db: &mut DB,
         is_optimism: bool,
-    ) -> Result<Option<L1BlockInfo>, EVMError<DB::Error>> {
+    ) -> Result<Option<L1BlockInfo>, DB::Error> {
         is_optimism
             .then(|| {
-                let l1_base_fee = db
-                    .storage(L1_BLOCK_CONTRACT, L1_BASE_FEE_SLOT)
-                    .map_err(EVMError::Database)?;
-                let l1_fee_overhead = db
-                    .storage(L1_BLOCK_CONTRACT, L1_OVERHEAD_SLOT)
-                    .map_err(EVMError::Database)?;
-                let l1_fee_scalar = db
-                    .storage(L1_BLOCK_CONTRACT, L1_SCALAR_SLOT)
-                    .map_err(EVMError::Database)?;
+                let l1_base_fee = db.storage(L1_BLOCK_CONTRACT, L1_BASE_FEE_SLOT)?;
+                let l1_fee_overhead = db.storage(L1_BLOCK_CONTRACT, L1_OVERHEAD_SLOT)?;
+                let l1_fee_scalar = db.storage(L1_BLOCK_CONTRACT, L1_SCALAR_SLOT)?;
 
                 Ok(L1BlockInfo {
                     l1_base_fee,

--- a/crates/revm/src/optimism.rs
+++ b/crates/revm/src/optimism.rs
@@ -47,21 +47,25 @@ impl L1BlockInfo {
         db: &mut DB,
         is_optimism: bool,
     ) -> Result<Option<L1BlockInfo>, EVMError<DB::Error>> {
-        let l1_base_fee = db
-            .storage(L1_BLOCK_CONTRACT, L1_BASE_FEE_SLOT)
-            .map_err(EVMError::Database)?;
-        let l1_fee_overhead = db
-            .storage(L1_BLOCK_CONTRACT, L1_OVERHEAD_SLOT)
-            .map_err(EVMError::Database)?;
-        let l1_fee_scalar = db
-            .storage(L1_BLOCK_CONTRACT, L1_SCALAR_SLOT)
-            .map_err(EVMError::Database)?;
+        is_optimism
+            .then(|| {
+                let l1_base_fee = db
+                    .storage(L1_BLOCK_CONTRACT, L1_BASE_FEE_SLOT)
+                    .map_err(EVMError::Database)?;
+                let l1_fee_overhead = db
+                    .storage(L1_BLOCK_CONTRACT, L1_OVERHEAD_SLOT)
+                    .map_err(EVMError::Database)?;
+                let l1_fee_scalar = db
+                    .storage(L1_BLOCK_CONTRACT, L1_SCALAR_SLOT)
+                    .map_err(EVMError::Database)?;
 
-        Ok(is_optimism.then_some(L1BlockInfo {
-            l1_base_fee,
-            l1_fee_overhead,
-            l1_fee_scalar,
-        }))
+                Ok(L1BlockInfo {
+                    l1_base_fee,
+                    l1_fee_overhead,
+                    l1_fee_scalar,
+                })
+            })
+            .map_or(Ok(None), |v| v.map(Some))
     }
 
     /// Calculate the data gas for posting the transaction on L1. Calldata costs 16 gas per non-zero

--- a/crates/revm/src/optimism.rs
+++ b/crates/revm/src/optimism.rs
@@ -2,9 +2,7 @@
 
 use core::ops::Mul;
 use revm_interpreter::primitives::{
-    db::{Database, DatabaseRef},
-    hex_literal::hex,
-    Bytes, EVMError, Spec, SpecId, B160, U256,
+    db::Database, hex_literal::hex, Bytes, EVMError, Spec, SpecId, B160, U256,
 };
 
 const ZERO_BYTE_COST: u64 = 4;
@@ -45,29 +43,8 @@ pub struct L1BlockInfo {
 }
 
 impl L1BlockInfo {
-    pub fn try_fetch_mut<DB: Database>(
+    pub fn try_fetch<DB: Database>(
         db: &mut DB,
-        is_optimism: bool,
-    ) -> Result<Option<L1BlockInfo>, EVMError<DB::Error>> {
-        let l1_base_fee = db
-            .storage(L1_BLOCK_CONTRACT, L1_BASE_FEE_SLOT)
-            .map_err(EVMError::Database)?;
-        let l1_fee_overhead = db
-            .storage(L1_BLOCK_CONTRACT, L1_OVERHEAD_SLOT)
-            .map_err(EVMError::Database)?;
-        let l1_fee_scalar = db
-            .storage(L1_BLOCK_CONTRACT, L1_SCALAR_SLOT)
-            .map_err(EVMError::Database)?;
-
-        Ok(is_optimism.then_some(L1BlockInfo {
-            l1_base_fee,
-            l1_fee_overhead,
-            l1_fee_scalar,
-        }))
-    }
-
-    pub fn try_fetch<DB: DatabaseRef>(
-        db: &DB,
         is_optimism: bool,
     ) -> Result<Option<L1BlockInfo>, EVMError<DB::Error>> {
         let l1_base_fee = db


### PR DESCRIPTION
## Overview

Only loads the `L1BlockInfo` once rather than twice.