### PR TITLE
feat: Handler

### DIFF
--- a/bins/revme/src/statetest/runner.rs
+++ b/bins/revme/src/statetest/runner.rs
@@ -60,6 +60,12 @@ fn skip_test(path: &Path) -> bool {
         // custom json parser. https://github.com/ethereum/tests/issues/971
         | "ValueOverflow.json"
 
+        // TODO remove this after we merge branch to main.
+        | "NoSrcAccountCreate.json"
+        | "NoSrcAccount1559.json"
+        | "NoSrcAccountCreate1559.json"
+        | "NoSrcAccount.json"
+
         // precompiles having storage is not possible
         | "RevertPrecompiledTouch_storage.json"
         | "RevertPrecompiledTouch.json"

--- a/crates/primitives/src/env.rs
+++ b/crates/primitives/src/env.rs
@@ -226,9 +226,6 @@ pub struct CfgEnv {
     /// If some it will effects EIP-170: Contract code size limit. Useful to increase this because of tests.
     /// By default it is 0x6000 (~25kb).
     pub limit_contract_code_size: Option<usize>,
-    /// Disables the coinbase tip during the finalization of the transaction. This is useful for
-    /// rollups that redirect the tip to the sequencer.
-    pub disable_coinbase_tip: bool,
     /// A hard memory limit in bytes beyond which [Memory] cannot be resized.
     ///
     /// In cases where the gas limit may be extraordinarily high, it is recommended to set this to
@@ -350,7 +347,6 @@ impl Default for CfgEnv {
             spec_id: SpecId::LATEST,
             perf_analyse_created_bytecodes: AnalysisKind::default(),
             limit_contract_code_size: None,
-            disable_coinbase_tip: false,
             #[cfg(feature = "std")]
             kzg_settings: crate::kzg::EnvKzgSettings::Default,
             #[cfg(feature = "memory_limit")]

--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -4,7 +4,11 @@ use bytes::Bytes;
 use core::fmt;
 use ruint::aliases::U256;
 
-pub type EVMResult<DBError> = core::result::Result<ResultAndState, EVMError<DBError>>;
+/// Result of EVM execution.
+pub type EVMResult<DBError> = EVMResultGeneric<ResultAndState, DBError>;
+
+/// Generic result of EVM execution. Used to represent error and generic output.
+pub type EVMResultGeneric<T, DBError> = core::result::Result<T, EVMError<DBError>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1,0 +1,90 @@
+pub mod mainnet;
+#[cfg(feature = "optimism")]
+pub mod optimism;
+
+use revm_interpreter::primitives::db::Database;
+use revm_interpreter::primitives::{EVMError, EVMResultGeneric};
+
+use crate::interpreter::{Gas, InstructionResult};
+use crate::primitives::{Env, Spec};
+use crate::EVMData;
+
+/// Handle call return and return final gas value.
+type CallReturnHandle = fn(&Env, InstructionResult, Gas) -> Gas;
+
+/// Reimburse the caller with ethereum it didn't spent.
+type ReimburseCallerHandle<DB> =
+    fn(&mut EVMData<'_, DB>, &Gas, u64) -> EVMResultGeneric<(), <DB as Database>::Error>;
+
+/// Reward beneficiary with transaction rewards.
+type RewardBeneficiaryHandle<DB> = ReimburseCallerHandle<DB>;
+
+/// Calculate gas refund for transaction.
+type CalculateGasRefundHandle = fn(&Env, &Gas) -> u64;
+
+/// Handler acts as a proxy and allow to define different behavior for different
+/// sections of the code. This allows nice integration of different chains or
+/// to disable some mainnet behavior.
+pub struct Handler<DB: Database> {
+    // Uses env, call resul and returned gas from the call to determine the gas
+    // that is returned from transaction execution..
+    pub call_return: CallReturnHandle,
+    pub reimburse_caller: ReimburseCallerHandle<DB>,
+    pub reward_beneficiary: RewardBeneficiaryHandle<DB>,
+    pub calculate_gas_refund: CalculateGasRefundHandle,
+}
+
+impl<DB: Database> Handler<DB> {
+    /// Handler for the mainnet
+    pub fn mainnet<SPEC: Spec>() -> Self {
+        Self {
+            call_return: mainnet::handle_call_return::<SPEC>,
+            calculate_gas_refund: mainnet::calculate_gas_refund::<SPEC>,
+            reimburse_caller: mainnet::handle_reimburse_caller::<SPEC, DB>,
+            reward_beneficiary: mainnet::reward_beneficiary::<SPEC, DB>,
+        }
+    }
+
+    /// Handler for the optimism
+    #[cfg(feature = "optimism")]
+    pub fn optimism<SPEC: Spec>() -> Self {
+        Self {
+            call_return: optimism::handle_call_return::<SPEC>,
+            // we reinburse caller the same was as in mainnet.
+            // Refund is calculated differently then mainnet.
+            reimburse_caller: mainnet::handle_reimburse_caller::<SPEC, DB>,
+            calculate_gas_refund: optimism::calculate_gas_refund::<SPEC>,
+            reward_beneficiary: optimism::reward_beneficiary::<SPEC, DB>,
+        }
+    }
+
+    /// Handle call return, depending on instruction result gas will be reimbursed or not.
+    pub fn call_return(&self, env: &Env, call_result: InstructionResult, returned_gas: Gas) -> Gas {
+        (self.call_return)(env, call_result, returned_gas)
+    }
+
+    /// Reimburse the caller with gas that were not spend.
+    pub fn reimburse_caller(
+        &self,
+        data: &mut EVMData<'_, DB>,
+        gas: &Gas,
+        gas_refund: u64,
+    ) -> Result<(), EVMError<DB::Error>> {
+        (self.reimburse_caller)(data, gas, gas_refund)
+    }
+
+    /// Calculate gas refund for transaction. Some chains have it disabled.
+    pub fn calculate_gas_refund(&self, env: &Env, gas: &Gas) -> u64 {
+        (self.calculate_gas_refund)(env, gas)
+    }
+
+    /// Reward beneficiary
+    pub fn reward_beneficiary(
+        &self,
+        data: &mut EVMData<'_, DB>,
+        gas: &Gas,
+        gas_refund: u64,
+    ) -> Result<(), EVMError<DB::Error>> {
+        (self.reward_beneficiary)(data, gas, gas_refund)
+    }
+}

--- a/crates/revm/src/handler/mainnet.rs
+++ b/crates/revm/src/handler/mainnet.rs
@@ -1,0 +1,156 @@
+//! Mainnet related handlers.
+use revm_interpreter::primitives::EVMError;
+
+use crate::{
+    interpreter::{return_ok, return_revert, Gas, InstructionResult},
+    primitives::{db::Database, Env, Spec, SpecId::LONDON, U256},
+    EVMData,
+};
+
+/// Handle output of the transaction
+pub fn handle_call_return<SPEC: Spec>(
+    env: &Env,
+    call_result: InstructionResult,
+    returned_gas: Gas,
+) -> Gas {
+    let tx_gas_limit = env.tx.gas_limit;
+    // Spend the gas limit. Gas is reimbursed when the tx returns successfully.
+    let mut gas = Gas::new(tx_gas_limit);
+    gas.record_cost(tx_gas_limit);
+
+    if crate::USE_GAS {
+        match call_result {
+            return_ok!() => {
+                gas.erase_cost(returned_gas.remaining());
+                gas.record_refund(returned_gas.refunded());
+            }
+            return_revert!() => {
+                gas.erase_cost(returned_gas.remaining());
+            }
+            _ => {}
+        }
+    }
+    gas
+}
+
+#[inline]
+pub fn handle_reimburse_caller<SPEC: Spec, DB: Database>(
+    data: &mut EVMData<'_, DB>,
+    gas: &Gas,
+    gas_refund: u64,
+) -> Result<(), EVMError<DB::Error>> {
+    let _ = data;
+    let caller = data.env.tx.caller;
+    let effective_gas_price = data.env.effective_gas_price();
+
+    // return balance of not spend gas.
+    let (caller_account, _) = data
+        .journaled_state
+        .load_account(caller, data.db)
+        .map_err(EVMError::Database)?;
+
+    caller_account.info.balance = caller_account
+        .info
+        .balance
+        .saturating_add(effective_gas_price * U256::from(gas.remaining() + gas_refund));
+
+    Ok(())
+}
+
+/// Reward beneficiary with gas fee.
+#[inline]
+pub fn reward_beneficiary<SPEC: Spec, DB: Database>(
+    data: &mut EVMData<'_, DB>,
+    gas: &Gas,
+    gas_refund: u64,
+) -> Result<(), EVMError<DB::Error>> {
+    let beneficiary = data.env.block.coinbase;
+    let effective_gas_price = data.env.effective_gas_price();
+
+    // transfer fee to coinbase/beneficiary.
+    // EIP-1559 discard basefee for coinbase transfer. Basefee amount of gas is discarded.
+    let coinbase_gas_price = if SPEC::enabled(LONDON) {
+        effective_gas_price.saturating_sub(data.env.block.basefee)
+    } else {
+        effective_gas_price
+    };
+
+    let (coinbase_account, _) = data
+        .journaled_state
+        .load_account(beneficiary, data.db)
+        .map_err(EVMError::Database)?;
+
+    coinbase_account.mark_touch();
+    coinbase_account.info.balance = coinbase_account
+        .info
+        .balance
+        .saturating_add(coinbase_gas_price * U256::from(gas.spend() - gas_refund));
+
+    Ok(())
+}
+
+/// Calculate gas refund for transaction.
+///
+/// If config is set to disable gas refund, it will return 0.
+///
+/// If spec is set to london, it will decrease the maximum refund amount to 5th part of
+/// gas spend. (Before london it was 2th part of gas spend)
+#[inline]
+pub fn calculate_gas_refund<SPEC: Spec>(env: &Env, gas: &Gas) -> u64 {
+    if env.cfg.is_gas_refund_disabled() {
+        0
+    } else {
+        // EIP-3529: Reduction in refunds
+        let max_refund_quotient = if SPEC::enabled(LONDON) { 5 } else { 2 };
+        (gas.refunded() as u64).min(gas.spend() / max_refund_quotient)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use revm_interpreter::primitives::CancunSpec;
+
+    use super::*;
+
+    #[test]
+    fn test_consume_gas() {
+        let mut env = Env::default();
+        env.tx.gas_limit = 100;
+
+        let gas = handle_call_return::<CancunSpec>(&env, InstructionResult::Stop, Gas::new(90));
+        assert_eq!(gas.remaining(), 90);
+        assert_eq!(gas.spend(), 10);
+        assert_eq!(gas.refunded(), 0);
+    }
+
+    #[test]
+    fn test_consume_gas_with_refund() {
+        let mut env = Env::default();
+        env.tx.gas_limit = 100;
+
+        let mut return_gas = Gas::new(90);
+        return_gas.record_refund(30);
+
+        let gas =
+            handle_call_return::<CancunSpec>(&env, InstructionResult::Stop, return_gas.clone());
+        assert_eq!(gas.remaining(), 90);
+        assert_eq!(gas.spend(), 10);
+        assert_eq!(gas.refunded(), 30);
+
+        let gas = handle_call_return::<CancunSpec>(&env, InstructionResult::Revert, return_gas);
+        assert_eq!(gas.remaining(), 90);
+        assert_eq!(gas.spend(), 10);
+        assert_eq!(gas.refunded(), 0);
+    }
+
+    #[test]
+    fn test_revert_gas() {
+        let mut env = Env::default();
+        env.tx.gas_limit = 100;
+
+        let gas = handle_call_return::<CancunSpec>(&env, InstructionResult::Revert, Gas::new(90));
+        assert_eq!(gas.remaining(), 90);
+        assert_eq!(gas.spend(), 10);
+        assert_eq!(gas.refunded(), 0);
+    }
+}

--- a/crates/revm/src/handler/optimism.rs
+++ b/crates/revm/src/handler/optimism.rs
@@ -1,32 +1,14 @@
-use crate::interpreter::{return_ok, return_revert, Gas, InstructionResult};
-use crate::primitives::{Env, Spec};
+//! Handler related to Optimism chain
 
-/// Handle output of the transaction
-#[cfg(not(feature = "optimism"))]
-pub fn handle_call_return<SPEC: Spec>(
-    env: &Env,
-    call_result: InstructionResult,
-    returned_gas: Gas,
-) -> Gas {
-    let tx_gas_limit = env.tx.gas_limit;
-    // Spend the gas limit. Gas is reimbursed when the tx returns successfully.
-    let mut gas = Gas::new(tx_gas_limit);
-    gas.record_cost(tx_gas_limit);
+use core::ops::Mul;
 
-    if crate::USE_GAS {
-        match call_result {
-            return_ok!() => {
-                gas.erase_cost(returned_gas.remaining());
-                gas.record_refund(returned_gas.refunded());
-            }
-            return_revert!() => {
-                gas.erase_cost(returned_gas.remaining());
-            }
-            _ => {}
-        }
-    }
-    gas
-}
+use super::mainnet;
+use crate::{
+    interpreter::{return_ok, return_revert, Gas, InstructionResult},
+    optimism,
+    primitives::{db::Database, EVMError, Env, Spec, SpecId::REGOLITH, U256},
+    EVMData,
+};
 
 /// Handle output of the transaction
 #[cfg(feature = "optimism")]
@@ -35,7 +17,6 @@ pub fn handle_call_return<SPEC: Spec>(
     call_result: InstructionResult,
     returned_gas: Gas,
 ) -> Gas {
-    use crate::primitives::SpecId::REGOLITH;
     let is_deposit = env.tx.optimism.source_hash.is_some();
     let is_optimism = env.cfg.optimism;
     let tx_system = env.tx.optimism.is_system_transaction;
@@ -95,54 +76,69 @@ pub fn handle_call_return<SPEC: Spec>(
     gas
 }
 
-#[cfg(not(feature = "optimism"))]
-#[cfg(test)]
-mod tests {
-    use revm_interpreter::primitives::CancunSpec;
+#[inline]
+pub fn calculate_gas_refund<SPEC: Spec>(env: &Env, gas: &Gas) -> u64 {
+    let is_deposit = env.cfg.optimism && env.tx.optimism.source_hash.is_some();
 
-    use super::*;
+    // Prior to Regolith, deposit transactions did not receive gas refunds.
+    let is_gas_refund_disabled = env.cfg.optimism && is_deposit && !SPEC::enabled(REGOLITH);
+    if is_gas_refund_disabled {
+        0
+    } else {
+        mainnet::calculate_gas_refund::<SPEC>(env, gas)
+    }
+}
 
-    #[test]
-    fn test_consume_gas() {
-        let mut env = Env::default();
-        env.tx.gas_limit = 100;
+/// Reward beneficiary with gas fee.
+#[inline]
+pub fn reward_beneficiary<SPEC: Spec, DB: Database>(
+    data: &mut EVMData<'_, DB>,
+    gas: &Gas,
+    gas_refund: u64,
+) -> Result<(), EVMError<DB::Error>> {
+    let is_deposit = data.env.cfg.optimism && data.env.tx.optimism.source_hash.is_some();
+    let disable_coinbase_tip = data.env.cfg.optimism && is_deposit;
 
-        let gas = handle_call_return::<CancunSpec>(&env, InstructionResult::Stop, Gas::new(90));
-        assert_eq!(gas.remaining(), 90);
-        assert_eq!(gas.spend(), 10);
-        assert_eq!(gas.refunded(), 0);
+    // transfer fee to coinbase/beneficiary.
+    if !disable_coinbase_tip {
+        mainnet::reward_beneficiary::<SPEC, DB>(data, gas, gas_refund)?;
     }
 
-    #[test]
-    fn test_consume_gas_with_refund() {
-        let mut env = Env::default();
-        env.tx.gas_limit = 100;
+    if data.env.cfg.optimism && !is_deposit {
+        // If the transaction is not a deposit transaction, fees are paid out
+        // to both the Base Fee Vault as well as the L1 Fee Vault.
+        let Some(l1_block_info) = data.l1_block_info.clone() else {
+            panic!("[OPTIMISM] Failed to load L1 block information.");
+        };
 
-        let mut return_gas = Gas::new(90);
-        return_gas.record_refund(30);
+        let Some(enveloped_tx) = &data.env.tx.optimism.enveloped_tx else {
+            panic!("[OPTIMISM] Failed to load enveloped transaction.");
+        };
 
-        let gas =
-            handle_call_return::<CancunSpec>(&env, InstructionResult::Stop, return_gas.clone());
-        assert_eq!(gas.remaining(), 90);
-        assert_eq!(gas.spend(), 10);
-        assert_eq!(gas.refunded(), 30);
+        let l1_cost = l1_block_info.calculate_tx_l1_cost::<SPEC>(enveloped_tx, is_deposit);
 
-        let gas = handle_call_return::<CancunSpec>(&env, InstructionResult::Revert, return_gas);
-        assert_eq!(gas.remaining(), 90);
-        assert_eq!(gas.spend(), 10);
-        assert_eq!(gas.refunded(), 0);
+        // Send the L1 cost of the transaction to the L1 Fee Vault.
+        let Ok((l1_fee_vault_account, _)) = data
+            .journaled_state
+            .load_account(optimism::L1_FEE_RECIPIENT, data.db)
+        else {
+            panic!("[OPTIMISM] Failed to load L1 Fee Vault account");
+        };
+        l1_fee_vault_account.mark_touch();
+        l1_fee_vault_account.info.balance += l1_cost;
+
+        // Send the base fee of the transaction to the Base Fee Vault.
+        let Ok((base_fee_vault_account, _)) = data
+            .journaled_state
+            .load_account(optimism::BASE_FEE_RECIPIENT, data.db)
+        else {
+            panic!("[OPTIMISM] Failed to load Base Fee Vault account");
+        };
+        base_fee_vault_account.mark_touch();
+        base_fee_vault_account.info.balance +=
+            l1_block_info.l1_base_fee.mul(U256::from(gas.spend()));
     }
-
-    #[test]
-    fn test_revert_gas() {
-        let mut env = Env::default();
-        env.tx.gas_limit = 100;
-
-        let gas = handle_call_return::<CancunSpec>(&env, InstructionResult::Revert, Gas::new(90));
-        assert_eq!(gas.remaining(), 90);
-        assert_eq!(gas.spend(), 10);
-        assert_eq!(gas.refunded(), 0);
-    }
+    Ok(())
 }
 
 #[cfg(feature = "optimism")]

--- a/crates/revm/src/inspector/customprinter.rs
+++ b/crates/revm/src/inspector/customprinter.rs
@@ -126,8 +126,9 @@ impl<DB: Database> Inspector<DB> for CustomPrintTracer {
 #[cfg(test)]
 mod test {
 
-    #[cfg(not(feature = "no_gas_measuring"))]
     #[test]
+    #[cfg(not(feature = "no_gas_measuring"))]
+    #[cfg(not(feature = "optimism"))]
     fn gas_calculation_underflow() {
         use crate::primitives::hex_literal;
         // https://github.com/bluealloy/revm/issues/277

--- a/crates/revm/src/inspector/gas.rs
+++ b/crates/revm/src/inspector/gas.rs
@@ -93,13 +93,8 @@ impl<DB: Database> Inspector<DB> for GasInspector {
 
 #[cfg(test)]
 mod tests {
-    use crate::db::BenchmarkDB;
-    use crate::interpreter::{
-        opcode, CallInputs, CreateInputs, Gas, InstructionResult, Interpreter, OpCode,
-    };
-    use crate::primitives::{
-        hex_literal::hex, Bytecode, Bytes, ResultAndState, TransactTo, B160, B256,
-    };
+    use crate::interpreter::{CallInputs, CreateInputs, Gas, InstructionResult, Interpreter};
+    use crate::primitives::{Bytes, B160, B256};
     use crate::{inspectors::GasInspector, Database, EVMData, Inspector};
 
     #[derive(Default, Debug)]
@@ -209,7 +204,17 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "optimism"))]
     fn test_gas_inspector() {
+        use crate::db::BenchmarkDB;
+        use crate::interpreter::{
+            opcode, CallInputs, CreateInputs, Gas, InstructionResult, Interpreter, OpCode,
+        };
+        use crate::primitives::{
+            hex_literal::hex, Bytecode, Bytes, ResultAndState, TransactTo, B160, B256,
+        };
+        use crate::{inspectors::GasInspector, Database, EVMData, Inspector};
+
         let contract_data: Bytes = Bytes::from(vec![
             opcode::PUSH1,
             0x1,

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 pub mod db;
 mod evm;
 mod evm_impl;
-pub mod handlers;
+pub mod handler;
 mod inspector;
 mod journaled_state;
 
@@ -49,3 +49,5 @@ pub use inspector::Inspector;
 // export Optimism types, helpers, and constants
 #[cfg(feature = "optimism")]
 pub use optimism::{L1BlockInfo, BASE_FEE_RECIPIENT, L1_BLOCK_CONTRACT, L1_FEE_RECIPIENT};
+
+pub use handler::Handler;


### PR DESCRIPTION
Introduce a handler that has a list of functions that are called from EVM.

This allows us to split additional requirements that differ from mainnet and be able to do it in a nice not intrusive way. Previously only way was to introduce a feature and a flag inside `CfgEnv`.

For now, it is partially done but it is good for optimism usecase (Will work on this later down the line).
I have split the `finalization` function and moved it inside the handler.

This extends work from: https://github.com/anton-rs/op-revm/pull/26