### PR TITLE
fix: feature matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
           cache-on-failure: true
 
       - name: cargo test
+        run: cargo test --workspace
+
+      - name: cargo test all features
         run: cargo test --workspace --all-features
       
       - name: cargo check no_std

--- a/crates/revm/src/handler/mainnet.rs
+++ b/crates/revm/src/handler/mainnet.rs
@@ -107,6 +107,7 @@ pub fn calculate_gas_refund<SPEC: Spec>(env: &Env, gas: &Gas) -> u64 {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "optimism"))]
 mod tests {
     use revm_interpreter::primitives::CancunSpec;
 

--- a/crates/revm/src/handler/optimism.rs
+++ b/crates/revm/src/handler/optimism.rs
@@ -150,6 +150,21 @@ mod tests {
     use crate::primitives::B256;
 
     #[test]
+    #[cfg(feature = "no_gas_measuring")]
+    fn test_revert_gas() {
+        let mut env = Env::default();
+        env.tx.gas_limit = 100;
+        env.cfg.optimism = true;
+        env.tx.optimism.source_hash = None;
+
+        let gas = handle_call_return::<BedrockSpec>(&env, InstructionResult::Revert, Gas::new(90));
+        assert_eq!(gas.remaining(), 0);
+        assert_eq!(gas.spend(), 100);
+        assert_eq!(gas.refunded(), 0);
+    }
+
+    #[test]
+    #[cfg(not(feature = "no_gas_measuring"))]
     fn test_revert_gas() {
         let mut env = Env::default();
         env.tx.gas_limit = 100;
@@ -184,8 +199,8 @@ mod tests {
         env.tx.optimism.source_hash = Some(B256::zero());
 
         let gas = handle_call_return::<RegolithSpec>(&env, InstructionResult::Stop, Gas::new(90));
-        assert_eq!(gas.remaining(), 90);
-        assert_eq!(gas.spend(), 10);
+        assert_eq!(gas.remaining(), 0);
+        assert_eq!(gas.spend(), 100);
         assert_eq!(gas.refunded(), 0);
     }
 
@@ -201,13 +216,13 @@ mod tests {
 
         let gas =
             handle_call_return::<RegolithSpec>(&env, InstructionResult::Stop, ret_gas.clone());
-        assert_eq!(gas.remaining(), 90);
-        assert_eq!(gas.spend(), 10);
-        assert_eq!(gas.refunded(), 20);
+        assert_eq!(gas.remaining(), 0);
+        assert_eq!(gas.spend(), 100);
+        assert_eq!(gas.refunded(), 0);
 
         let gas = handle_call_return::<RegolithSpec>(&env, InstructionResult::Revert, ret_gas);
-        assert_eq!(gas.remaining(), 90);
-        assert_eq!(gas.spend(), 10);
+        assert_eq!(gas.remaining(), 0);
+        assert_eq!(gas.spend(), 100);
         assert_eq!(gas.refunded(), 0);
     }
 


### PR DESCRIPTION
**Description**

Fixes tests in the call handlers for the various feature matrices.

Upstream tests were failing because the `--all-features` flag hit _both_ the `optimism` and `no_gas_measuring` flags.

Since `no_gas_measuring` is used for the crate-level [`USE_GAS` constant](https://github.com/anton-rs/op-revm/blob/clabby/op-revm/crates/revm/src/lib.rs#L20), as inlined below, optimism and mainnet tests were not hitting the `USE_GAS` paths. Further, the `mainnet` tests were hitting the `optimism` call handler path since `--all-features` activated the optimism `call_handler`.

```rust
pub(crate) const USE_GAS: bool = !cfg!(feature = "no_gas_measuring");
```