### PR TITLE
remove USE_GAS from handlers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
           cache-on-failure: true
 
       - name: cargo test
+        run: cargo test --workspace
+
+      - name: cargo test all features
         run: cargo test --workspace --all-features
       
       - name: cargo check no_std

--- a/crates/revm/src/handler/mainnet.rs
+++ b/crates/revm/src/handler/mainnet.rs
@@ -18,17 +18,15 @@ pub fn handle_call_return<SPEC: Spec>(
     let mut gas = Gas::new(tx_gas_limit);
     gas.record_cost(tx_gas_limit);
 
-    if crate::USE_GAS {
-        match call_result {
-            return_ok!() => {
-                gas.erase_cost(returned_gas.remaining());
-                gas.record_refund(returned_gas.refunded());
-            }
-            return_revert!() => {
-                gas.erase_cost(returned_gas.remaining());
-            }
-            _ => {}
+    match call_result {
+        return_ok!() => {
+            gas.erase_cost(returned_gas.remaining());
+            gas.record_refund(returned_gas.refunded());
         }
+        return_revert!() => {
+            gas.erase_cost(returned_gas.remaining());
+        }
+        _ => {}
     }
     gas
 }


### PR DESCRIPTION
supersedes https://github.com/anton-rs/op-revm/pull/29

It removed `USE_GAS` and removed a need to change tests.