### PR TITLE
refactor optimism: main_return

### DIFF
--- a/crates/primitives/src/result.rs
+++ b/crates/primitives/src/result.rs
@@ -47,6 +47,11 @@ impl ExecutionResult {
         matches!(self, Self::Success { .. })
     }
 
+    /// Returns true if execution result is a Halt.
+    pub fn is_halt(&self) -> bool {
+        matches!(self, Self::Halt { .. })
+    }
+
     /// Return logs, if execution is not successful, function will return empty vec.
     pub fn logs(&self) -> Vec<Log> {
         match self {


### PR DESCRIPTION
Makes a `main_return` a lot smaller and cleaner as it extends the `mainnet` handle