### PR TITLE
chore: Introduce end handle

### DIFF
--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -85,10 +85,7 @@ pub trait Transact<DBError> {
     fn transact_preverified(&mut self) -> EVMResult<DBError>;
 
     /// Execute transaction by running pre-verification steps and then transaction itself.
-    fn transact(&mut self) -> EVMResult<DBError> {
-        self.preverify_transaction()
-            .and_then(|_| self.transact_preverified())
-    }
+    fn transact(&mut self) -> EVMResult<DBError>;
 }
 
 impl<'a, DB: Database> EVMData<'a, DB> {
@@ -178,8 +175,8 @@ impl<'a, GSPEC: Spec + 'static, DB: Database> Transact<DB::Error> for EVMImpl<'a
     #[inline]
     fn transact(&mut self) -> EVMResult<DB::Error> {
         let output = self
-            .preverify_transaction()
-            .and_then(|()| self.transact_preverified());
+            .preverify_transaction_inner()
+            .and_then(|()| self.transact_preverified_inner());
         self.handler.end(&mut self.data, output)
     }
 }

--- a/crates/revm/src/evm_impl.rs
+++ b/crates/revm/src/evm_impl.rs
@@ -85,7 +85,10 @@ pub trait Transact<DBError> {
     fn transact_preverified(&mut self) -> EVMResult<DBError>;
 
     /// Execute transaction by running pre-verification steps and then transaction itself.
-    fn transact(&mut self) -> EVMResult<DBError>;
+    fn transact(&mut self) -> EVMResult<DBError> {
+        self.preverify_transaction()
+            .and_then(|_| self.transact_preverified())
+    }
 }
 
 impl<'a, DB: Database> EVMData<'a, DB> {
@@ -161,7 +164,71 @@ impl<'a, GSPEC: Spec, DB: Database> EVMImpl<'a, GSPEC, DB> {
 }
 
 impl<'a, GSPEC: Spec + 'static, DB: Database> Transact<DB::Error> for EVMImpl<'a, GSPEC, DB> {
+    #[inline]
     fn preverify_transaction(&mut self) -> Result<(), EVMError<DB::Error>> {
+        self.preverify_transaction_inner()
+    }
+
+    #[inline]
+    fn transact_preverified(&mut self) -> EVMResult<DB::Error> {
+        let output = self.transact_preverified_inner();
+        self.handler.end(&mut self.data, output)
+    }
+
+    #[inline]
+    fn transact(&mut self) -> EVMResult<DB::Error> {
+        let output = self
+            .preverify_transaction()
+            .and_then(|()| self.transact_preverified());
+        self.handler.end(&mut self.data, output)
+    }
+}
+
+impl<'a, GSPEC: Spec + 'static, DB: Database> EVMImpl<'a, GSPEC, DB> {
+    pub fn new(
+        db: &'a mut DB,
+        env: &'a mut Env,
+        inspector: Option<&'a mut dyn Inspector<DB>>,
+        precompiles: Precompiles,
+    ) -> Self {
+        let journaled_state = JournaledState::new(precompiles.len(), GSPEC::SPEC_ID);
+        let instruction_table = if inspector.is_some() {
+            let instruction_table = make_boxed_instruction_table::<Self, GSPEC, _>(
+                make_instruction_table::<Self, GSPEC>(),
+                inspector_instruction,
+            );
+            InstructionTables::Boxed(Arc::new(instruction_table))
+        } else {
+            InstructionTables::Plain(Arc::new(make_instruction_table::<Self, GSPEC>()))
+        };
+        #[cfg(feature = "optimism")]
+        let handler = if env.cfg.optimism {
+            Handler::optimism::<GSPEC>()
+        } else {
+            Handler::mainnet::<GSPEC>()
+        };
+        #[cfg(not(feature = "optimism"))]
+        let handler = Handler::mainnet::<GSPEC>();
+
+        Self {
+            data: EVMData {
+                env,
+                journaled_state,
+                db,
+                error: None,
+                precompiles,
+                #[cfg(feature = "optimism")]
+                l1_block_info: None,
+            },
+            inspector,
+            instruction_table,
+            handler,
+            _phantomdata: PhantomData {},
+        }
+    }
+
+    /// Pre verify transaction.
+    pub fn preverify_transaction_inner(&mut self) -> Result<(), EVMError<DB::Error>> {
         let env = self.env();
 
         // Important: validate block before tx.
@@ -193,7 +260,8 @@ impl<'a, GSPEC: Spec + 'static, DB: Database> Transact<DB::Error> for EVMImpl<'a
             .map_err(Into::into)
     }
 
-    fn transact_preverified(&mut self) -> EVMResult<DB::Error> {
+    /// Transact preverified transaction.
+    pub fn transact_preverified_inner(&mut self) -> EVMResult<DB::Error> {
         let env = &self.data.env;
         let tx_caller = env.tx.caller;
         let tx_value = env.tx.value;
@@ -346,63 +414,6 @@ impl<'a, GSPEC: Spec + 'static, DB: Database> Transact<DB::Error> for EVMImpl<'a
 
         // main return
         handler.main_return(data, call_result, output, &gas)
-    }
-
-    #[inline]
-    fn transact(&mut self) -> EVMResult<DB::Error> {
-        #[cfg(not(feature = "optimism"))]
-        {
-            crate::handler::mainnet::default_transact(self)
-        }
-
-        #[cfg(feature = "optimism")]
-        {
-            crate::handler::optimism::default_transact(self)
-        }
-    }
-}
-
-impl<'a, GSPEC: Spec + 'static, DB: Database> EVMImpl<'a, GSPEC, DB> {
-    pub fn new(
-        db: &'a mut DB,
-        env: &'a mut Env,
-        inspector: Option<&'a mut dyn Inspector<DB>>,
-        precompiles: Precompiles,
-    ) -> Self {
-        let journaled_state = JournaledState::new(precompiles.len(), GSPEC::SPEC_ID);
-        let instruction_table = if inspector.is_some() {
-            let instruction_table = make_boxed_instruction_table::<Self, GSPEC, _>(
-                make_instruction_table::<Self, GSPEC>(),
-                inspector_instruction,
-            );
-            InstructionTables::Boxed(Arc::new(instruction_table))
-        } else {
-            InstructionTables::Plain(Arc::new(make_instruction_table::<Self, GSPEC>()))
-        };
-        #[cfg(feature = "optimism")]
-        let handler = if env.cfg.optimism {
-            Handler::optimism::<GSPEC>()
-        } else {
-            Handler::mainnet::<GSPEC>()
-        };
-        #[cfg(not(feature = "optimism"))]
-        let handler = Handler::mainnet::<GSPEC>();
-
-        Self {
-            data: EVMData {
-                env,
-                journaled_state,
-                db,
-                error: None,
-                precompiles,
-                #[cfg(feature = "optimism")]
-                l1_block_info: None,
-            },
-            inspector,
-            instruction_table,
-            handler,
-            _phantomdata: PhantomData {},
-        }
     }
 
     #[inline(never)]

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -29,6 +29,15 @@ type MainReturnHandle<DB> = fn(
     &Gas,
 ) -> Result<ResultAndState, EVMError<<DB as Database>::Error>>;
 
+/// End handle, takes result and state and returns final result.
+/// This will be called after all the other handlers.
+///
+/// It is useful for catching errors and returning them in a different way.
+type EndHandle<DB> = fn(
+    &mut EVMData<'_, DB>,
+    evm_output: Result<ResultAndState, EVMError<<DB as Database>::Error>>,
+) -> Result<ResultAndState, EVMError<<DB as Database>::Error>>;
+
 /// Handler acts as a proxy and allow to define different behavior for different
 /// sections of the code. This allows nice integration of different chains or
 /// to disable some mainnet behavior.
@@ -45,6 +54,8 @@ pub struct Handler<DB: Database> {
     pub calculate_gas_refund: CalculateGasRefundHandle,
     /// Main return handle, returns the output of the transact.
     pub main_return: MainReturnHandle<DB>,
+    /// End handle.
+    pub end: EndHandle<DB>,
 }
 
 impl<DB: Database> Handler<DB> {
@@ -56,6 +67,7 @@ impl<DB: Database> Handler<DB> {
             reimburse_caller: mainnet::handle_reimburse_caller::<SPEC, DB>,
             reward_beneficiary: mainnet::reward_beneficiary::<SPEC, DB>,
             main_return: mainnet::main_return::<DB>,
+            end: mainnet::end_handle::<DB>,
         }
     }
 
@@ -69,7 +81,9 @@ impl<DB: Database> Handler<DB> {
             reimburse_caller: mainnet::handle_reimburse_caller::<SPEC, DB>,
             calculate_gas_refund: optimism::calculate_gas_refund::<SPEC>,
             reward_beneficiary: optimism::reward_beneficiary::<SPEC, DB>,
+            // In case of halt of deposit transaction return Error.
             main_return: optimism::main_return::<SPEC, DB>,
+            end: optimism::end_handle::<SPEC, DB>,
         }
     }
 
@@ -110,5 +124,14 @@ impl<DB: Database> Handler<DB> {
         gas: &Gas,
     ) -> Result<ResultAndState, EVMError<DB::Error>> {
         (self.main_return)(data, call_result, output, gas)
+    }
+
+    /// End handler.
+    pub fn end(
+        &self,
+        data: &mut EVMData<'_, DB>,
+        end_output: Result<ResultAndState, EVMError<DB::Error>>,
+    ) -> Result<ResultAndState, EVMError<DB::Error>> {
+        (self.end)(data, end_output)
     }
 }

--- a/crates/revm/src/handler/mainnet.rs
+++ b/crates/revm/src/handler/mainnet.rs
@@ -3,10 +3,10 @@
 use crate::{
     interpreter::{return_ok, return_revert, Gas, InstructionResult, SuccessOrHalt},
     primitives::{
-        db::Database, EVMError, EVMResult, Env, ExecutionResult, Output, ResultAndState, Spec,
-        SpecId::LONDON, U256,
+        db::Database, EVMError, Env, ExecutionResult, Output, ResultAndState, Spec, SpecId::LONDON,
+        U256,
     },
-    EVMData, EVMImpl, Transact,
+    EVMData,
 };
 
 /// Handle output of the transaction
@@ -150,12 +150,13 @@ pub fn main_return<DB: Database>(
     Ok(ResultAndState { result, state })
 }
 
+/// Mainnet end handle does not change the output.
 #[inline]
-pub fn default_transact<GSPEC: Spec + 'static, DB: Database>(
-    evm: &mut EVMImpl<'_, GSPEC, DB>,
-) -> EVMResult<DB::Error> {
-    evm.preverify_transaction()
-        .and_then(|_| evm.transact_preverified())
+pub fn end_handle<DB: Database>(
+    _data: &mut EVMData<'_, DB>,
+    evm_output: Result<ResultAndState, EVMError<DB::Error>>,
+) -> Result<ResultAndState, EVMError<DB::Error>> {
+    evm_output
 }
 
 #[cfg(test)]

--- a/crates/revm/src/handler/optimism.rs
+++ b/crates/revm/src/handler/optimism.rs
@@ -2,14 +2,13 @@
 
 use super::mainnet;
 use crate::{
-    interpreter::{return_ok, return_revert, Gas, Host, InstructionResult},
+    interpreter::{return_ok, return_revert, Gas, InstructionResult},
     optimism,
-    precompile::HashMap,
     primitives::{
-        db::Database, Account, EVMError, EVMResult, Env, ExecutionResult, Halt, InvalidTransaction,
+        db::Database, Account, EVMError, Env, ExecutionResult, Halt, HashMap, InvalidTransaction,
         Output, ResultAndState, Spec, SpecId::REGOLITH, U256,
     },
-    EVMData, EVMImpl, Transact,
+    EVMData,
 };
 use core::ops::Mul;
 
@@ -168,74 +167,72 @@ pub fn main_return<SPEC: Spec, DB: Database>(
     }
     Ok(result)
 }
-
+/// Optimism end handle changes output if the transaction is a deposit transaction.
+/// Deposit transaction can't be reverted and is always successful.
 #[inline]
-pub fn default_transact<GSPEC: Spec + 'static, DB: Database>(
-    evm: &mut EVMImpl<'_, GSPEC, DB>,
-) -> EVMResult<DB::Error> {
-    match evm
-        .preverify_transaction()
-        .and_then(|_| evm.transact_preverified())
-    {
-        Ok(res) => Ok(res),
-        Err(err) => {
-            if evm.env().cfg.optimism && evm.env().tx.optimism.source_hash.is_some() {
-                match err {
-                    EVMError::Header(_) | EVMError::Database(_) => Err(err),
-                    EVMError::Transaction(_) => {
-                        // If the transaction is a deposit transaction and it failed
-                        // for any reason, the caller nonce must be bumped, and the
-                        // gas reported must be altered depending on the Hardfork. This is
-                        // also returned as a special Halt variant so that consumers can more
-                        // easily distinguish between a failed deposit and a failed
-                        // normal transaction.
-                        let caller = evm.env().tx.caller;
+pub fn end_handle<SPEC: Spec, DB: Database>(
+    data: &mut EVMData<'_, DB>,
+    evm_output: Result<ResultAndState, EVMError<DB::Error>>,
+) -> Result<ResultAndState, EVMError<DB::Error>> {
+    evm_output.or_else(|err| {
+        if matches!(EVMError::Transaction(_), err)
+            && evm.env().cfg.optimism
+            && evm.env().tx.optimism.source_hash.is_some()
+        {
+            // If the transaction is a deposit transaction and it failed
+            // for any reason, the caller nonce must be bumped, and the
+            // gas reported must be altered depending on the Hardfork. This is
+            // also returned as a special Halt variant so that consumers can more
+            // easily distinguish between a failed deposit and a failed
+            // normal transaction.
+            let caller = data.env().tx.caller;
 
-                        // Increment sender nonce and account balance for the mint amount. Deposits
-                        // always persist the mint amount, even if the transaction fails.
-                        let account = {
-                            let mut acc = Account::from(
-                                evm.data
-                                    .db
-                                    .basic(caller)
-                                    .unwrap_or_default()
-                                    .unwrap_or_default(),
-                            );
-                            acc.info.nonce = acc.info.nonce.saturating_add(1);
-                            acc.info.balance = acc.info.balance.saturating_add(U256::from(
-                                evm.env().tx.optimism.mint.unwrap_or(0),
-                            ));
-                            acc.mark_touch();
-                            acc
-                        };
-                        let state = HashMap::from([(caller, account)]);
+            // Increment sender nonce and account balance for the mint amount. Deposits
+            // always persist the mint amount, even if the transaction fails.
+            let account = {
+                let mut acc = Account::from(
+                    data.db
+                        .basic(caller)
+                        .unwrap_or_default()
+                        .unwrap_or_default(),
+                );
+                acc.info.nonce = acc.info.nonce.saturating_add(1);
+                acc.info.balance = acc
+                    .info
+                    .balance
+                    .saturating_add(U256::from(data.env().tx.optimism.mint.unwrap_or(0)));
+                acc.mark_touch();
+                acc
+            };
+            let state = HashMap::from([(caller, account)]);
 
-                        // The gas used of a failed deposit post-regolith is the gas
-                        // limit of the transaction. pre-regolith, it is the gas limit
-                        // of the transaction for non system transactions and 0 for system
-                        // transactions.
-                        let is_system_tx =
-                            evm.env().tx.optimism.is_system_transaction.unwrap_or(false);
-                        let gas_used = if GSPEC::enabled(REGOLITH) || !is_system_tx {
-                            evm.env().tx.gas_limit
-                        } else {
-                            0
-                        };
-
-                        Ok(ResultAndState {
-                            result: ExecutionResult::Halt {
-                                reason: Halt::FailedDeposit,
-                                gas_used,
-                            },
-                            state,
-                        })
-                    }
-                }
+            // The gas used of a failed deposit post-regolith is the gas
+            // limit of the transaction. pre-regolith, it is the gas limit
+            // of the transaction for non system transactions and 0 for system
+            // transactions.
+            let is_system_tx = data
+                .env()
+                .tx
+                .optimism
+                .is_system_transaction
+                .unwrap_or(false);
+            let gas_used = if SPEC::enabled(REGOLITH) || !is_system_tx {
+                data.env().tx.gas_limit
             } else {
-                Err(err)
-            }
+                0
+            };
+
+            Ok(ResultAndState {
+                result: ExecutionResult::Halt {
+                    reason: Halt::FailedDeposit,
+                    gas_used,
+                },
+                state,
+            })
+        } else {
+            Err(err)
         }
-    }
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Introduce end_handle that allows handler to catch all errors. 

used inside Optimism to catch deposit transaction error and make into Halt.